### PR TITLE
Sprint #5

### DIFF
--- a/src/main/java/com/activegym/activegym/repository/Memberships/MembershipRepository.java
+++ b/src/main/java/com/activegym/activegym/repository/Memberships/MembershipRepository.java
@@ -115,7 +115,7 @@ public interface MembershipRepository extends JpaRepository<Membership, Long> {
      * @param userId the id of the user to be checked.
      * @return true if the user has an active membership, false otherwise.
      */
-    @Query("SELECT COUNT(m) > 0 FROM Membership m WHERE m.userId.id = :userId AND m.endDate >= CURRENT_DATE")
+    @Query("SELECT COUNT(m) > 0 FROM Membership m WHERE m.userId.id = :userId AND m.endDate >= CURRENT_DATE AND m.membershipStatus.description = 'ACTIVA'")
     boolean existsActiveMembership(@Param("userId") Long userId);
 
     /**

--- a/src/main/java/com/activegym/activegym/security/auth/AuthResponse.java
+++ b/src/main/java/com/activegym/activegym/security/auth/AuthResponse.java
@@ -27,4 +27,9 @@ public class AuthResponse {
      * The username of the authenticated user.
      */
     String userName;
+
+    /**
+     * The user profile picture
+     */
+    String profilePicture;
 }

--- a/src/main/java/com/activegym/activegym/security/auth/AuthService.java
+++ b/src/main/java/com/activegym/activegym/security/auth/AuthService.java
@@ -52,6 +52,8 @@ public class AuthService {
 
         String userName = jwtService.extractUserName(token);
 
+        String profilePicture = jwtService.getProfilePictureFromToken(token);
+
         List<String> authorities = user.getAuthorities().stream()
                 .map(GrantedAuthority::getAuthority)
                 .toList();
@@ -68,6 +70,7 @@ public class AuthService {
                 .body(AuthResponse.builder()
                         .token(token)
                         .userName(userName)
+                        .profilePicture(profilePicture)
                         .build());
     }
 

--- a/src/main/java/com/activegym/activegym/security/jwt/JwtService.java
+++ b/src/main/java/com/activegym/activegym/security/jwt/JwtService.java
@@ -58,12 +58,14 @@ public class JwtService {
         User customUser = (User) user;
         String document = customUser.getDocument();
         String userName = customUser.getFirstName();
+        String profilePicture = customUser.getProfilePicture();
 
         return Jwts
                 .builder()
                 .claims(extraClaims)
                 .claim("document", document)
                 .claim("userName", userName)
+                .claim("profilePicture", profilePicture)
                 .subject(user.getUsername())
                 .issuedAt(new Date(System.currentTimeMillis()))
                 .expiration(new Date(System.currentTimeMillis() + 1000 * 60 * 60)) // 1 hour expiration
@@ -89,6 +91,10 @@ public class JwtService {
      */
     public String getUsernameFromToken(String token) {
         return getClaim(token, Claims::getSubject);
+    }
+
+    public String getProfilePictureFromToken(String token) {
+        return getClaim(token, claims -> claims.get("profilePicture", String.class));
     }
 
     /**

--- a/src/main/java/com/activegym/activegym/service/Users/AccessControlService.java
+++ b/src/main/java/com/activegym/activegym/service/Users/AccessControlService.java
@@ -8,6 +8,7 @@ import com.activegym.activegym.model.Users.User;
 import com.activegym.activegym.repository.Memberships.MembershipRepository;
 import com.activegym.activegym.repository.Users.AccessLogRepository;
 import com.activegym.activegym.repository.Users.UserRepository;
+import com.activegym.activegym.util.FormatDateTime;
 import lombok.AllArgsConstructor;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
@@ -22,6 +23,7 @@ public class AccessControlService {
     private final UserRepository userRepository;
     private final AccessLogRepository accessLogRepository;
     private final MembershipRepository membershipRepository;
+    private final FormatDateTime formatDateTime;
     private static final List<String> teamRoles = List.of("ADMINISTRADOR", "ASESOR", "ENTRENADOR", "PERSONAL DE ASEO");
 
     public String access(String document) {
@@ -55,7 +57,7 @@ public class AccessControlService {
         return accessLogRepository.findAll(pageable)
                 .map(accessLog -> new UserAccessResponseDTO(
                         accessLog.getId(),
-                        accessLog.getAccessDateTime().toString(),
+                        formatDateTime.formatDateTime(accessLog.getAccessDateTime()),
                         accessLog.getSuccess(),
                         accessLog.getUserId().getDocument()
                 ));
@@ -71,7 +73,7 @@ public class AccessControlService {
         return accessLogRepository.findAllByUserId(user, pageable)
                 .map(accessLog -> new UserAccessResponseDTO(
                         accessLog.getId(),
-                        accessLog.getAccessDateTime().toString(),
+                        formatDateTime.formatDateTime(accessLog.getAccessDateTime()),
                         accessLog.getSuccess(),
                         accessLog.getUserId().getDocument()
                 ));

--- a/src/main/java/com/activegym/activegym/util/FormatDateTime.java
+++ b/src/main/java/com/activegym/activegym/util/FormatDateTime.java
@@ -1,0 +1,19 @@
+package com.activegym.activegym.util;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+import java.time.LocalDateTime;
+import java.time.format.DateTimeFormatter;
+
+@Service
+@RequiredArgsConstructor
+public class FormatDateTime {
+    public String formatDateTime(LocalDateTime dateTime) {
+        DateTimeFormatter dateFormatter = DateTimeFormatter.ofPattern("yyyy-MM-dd");
+        DateTimeFormatter timeFormatter = DateTimeFormatter.ofPattern("HH:mm:ss");
+        String formattedDate = dateTime.format(dateFormatter);
+        String formattedTime = dateTime.format(timeFormatter);
+        return formattedDate + " a las " + formattedTime;
+    }
+}


### PR DESCRIPTION
- Return profile picture as claim in auth response for frontend purposes.
- Deny access to gym stablishment through counter access module.
- Return datime as an understandable string (has a format as: "date (YYYY-MM-DD at HH:MM:SS).
- Allow members with team roles to access their own information through self-management endpoints.
- Some minor fixes.